### PR TITLE
fix: add lvm+dm modules to dracut

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -60,7 +60,7 @@ RUN --mount=type=tmpfs,dst=/tmp cd /tmp && \
 
 RUN env \
     KERNEL_VERSION="$(basename "$(find "${BOOTC_ROOTFS_MOUNTPOINT}/usr/lib/modules" -maxdepth 1 -type d | grep -v -E "*.img" | tail -n 1)")" \
-    sh -c 'dracut --force -r "${BOOTC_ROOTFS_MOUNTPOINT}" --no-hostonly --reproducible --zstd --verbose --kver "${KERNEL_VERSION}" --add ostree "${BOOTC_ROOTFS_MOUNTPOINT}/usr/lib/modules/${KERNEL_VERSION}/initramfs.img"'
+    sh -c 'dracut --force -r "${BOOTC_ROOTFS_MOUNTPOINT}" --no-hostonly --reproducible --zstd --verbose --kver "${KERNEL_VERSION}" --add ostree lvm dm "${BOOTC_ROOTFS_MOUNTPOINT}/usr/lib/modules/${KERNEL_VERSION}/initramfs.img"'
 
 RUN cd "${BOOTC_ROOTFS_MOUNTPOINT}" && \
     mkdir -p boot sysroot var/home && \


### PR DESCRIPTION
Simpler than #2. We only need these two.