### PR TITLE
Build with more privileged permissions

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -4,7 +4,7 @@ base_dir := env("BUILD_BASE_DIR", ".")
 filesystem := env("BUILD_FILESYSTEM", "ext4")
 
 build-containerfile $image_name=image_name:
-    sudo podman build -t "${image_name}:latest" .
+    sudo podman build -t "${image_name}:latest" . --userns=host --security-opt=label=type:container_runtime_t
 
 bootc *ARGS:
     sudo podman run \


### PR DESCRIPTION
Bootc upstream currently recommends the following:

`--cap-add=all --security-opt=label=type:container_runtime_t --device /dev/fuse`

If you look at the corresponding issue (https://gitlab.com/fedora/bootc/base-images/-/issues/43)

it becomes clear that `--userns=host --security-opt=label=type:container_runtime_t` will suffice.

Although the image builds now, following upstream guidance (especially if you're like me and you change the Containerfile) is probably better.