### PR TITLE
fix: add go-md2man

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,13 +8,13 @@ RUN pacman -Sy --noconfirm base dracut linux linux-firmware ostree btrfs-progs e
 
 # https://github.com/bootc-dev/bootc/issues/1801
 RUN --mount=type=tmpfs,dst=/tmp --mount=type=tmpfs,dst=/root \
-    pacman -S --noconfirm make git rust && \
+    pacman -S --noconfirm make git rust go-md2man && \
     git clone "https://github.com/bootc-dev/bootc.git" /tmp/bootc && \
     make -C /tmp/bootc bin install-all && \
     printf "systemdsystemconfdir=/etc/systemd/system\nsystemdsystemunitdir=/usr/lib/systemd/system\n" | tee /usr/lib/dracut/dracut.conf.d/30-bootcrew-fix-bootc-module.conf && \
     printf 'reproducible=yes\nhostonly=no\ncompress=zstd\nadd_dracutmodules+=" ostree bootc "' | tee "/usr/lib/dracut/dracut.conf.d/30-bootcrew-bootc-container-build.conf" && \
     dracut --force "$(find /usr/lib/modules -maxdepth 1 -type d | grep -v -E "*.img" | tail -n 1)/initramfs.img" && \
-    pacman -Rns --noconfirm make git rust && \
+    pacman -Rns --noconfirm make git rust go-md2man && \
     pacman -S --clean --noconfirm
 
 # Necessary for general behavior expected by image-based systems


### PR DESCRIPTION
https://github.com/bootc-dev/bootc/commit/e7472169802e21c8693c2ad3fe088af1782f73cc seems to have broken building bootc without go-md2man installed. This explicitly adds it during the bootc build process, and removes it when finished.