### PR TITLE
Add LABEL containers.bootc 1 to Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -30,4 +30,7 @@ RUN sed -i 's|^HOME=.*|HOME=/var/home|' "/etc/default/useradd" && \
 # RUN pacman -S whois --noconfirm
 # RUN usermod -p "$(echo "changeme" | mkpasswd -s)" root
 
+# https://bootc-dev.github.io/bootc/bootc-images.html#standard-metadata-for-bootc-compatible-images
+LABEL containers.bootc 1
+
 RUN bootc container lint


### PR DESCRIPTION
Add LABEL containers.bootc 1 to Containerfile

Label was only in build.yaml workflow, meaning local builds wouldn't
pass `bootc container lint`. Adding to Containerfile ensures compatibility.

Ref: https://bootc-dev.github.io/bootc/bootc-images.html#standard-metadata-for-bootc-compatible-images
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
