### PR TITLE
Remove NoExtract rules

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,7 @@ FROM docker.io/archlinux/archlinux:latest
 RUN grep "= */var" /etc/pacman.conf | sed "/= *\/var/s/.*=// ; s/ //" | xargs -n1 sh -c 'mkdir -p "/usr/lib/sysimage/$(dirname $(echo $1 | sed "s@/var/@@"))" && mv -v "$1" "/usr/lib/sysimage/$(echo "$1" | sed "s@/var/@@")"' '' && \
     sed -i -e "/= *\/var/ s/^#//" -e "s@= */var@= /usr/lib/sysimage@g" -e "/DownloadUser/d" /etc/pacman.conf
 
-# Replace NoExtract rules, otherwise no additional languages and help pages can be installed
+# Remove NoExtract rules, otherwise no additional languages and help pages can be installed
 # See https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/pacman-conf.d-noextract.conf?ref_type=heads
 RUN sed -i 's/^[[:space:]]*NoExtract/#&/' /etc/pacman.conf
 


### PR DESCRIPTION
Remove NoExtract rules from pacman.conf to allow using additional languages and help files. Reinstall glibc to fix missing language files.