### PR TITLE
containerfile: use a separate build stage for bootc

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 FROM docker.io/archlinux/archlinux:latest AS builder
-RUN pacman -Syu --noconfirm make git rust go-md2man ostree glibc
+RUN pacman -Syu --noconfirm make git rust go-md2man ostree glibc pkgconf
 WORKDIR /build/bootc
 RUN git clone "https://github.com/bootc-dev/bootc.git" . && \
     make bin install-all DESTDIR=/output


### PR DESCRIPTION
Using a build stage in a separate image, we don't pollute our base image with issues like bootc lint complaining about git not being in sysusers.